### PR TITLE
User input database Complete

### DIFF
--- a/src/user_input_database.py
+++ b/src/user_input_database.py
@@ -5,6 +5,7 @@ Creates and manages the user-input database
 import sqlite3
 import uuid
 
+
 class user_input_database:
 
     def __init__(self, stored_dbase):
@@ -12,7 +13,27 @@ class user_input_database:
         Sets up the database when the class is called. Creates an empty dbase 
         if no input, initializes based on the previous version if given an input
         """
-        pass
+        self.user_input_db = 'user_input_database.db'
+
+    def build_user_db(self):
+        """
+        Initialize database for successful user inputs
+        """
+        table = sqlite3.connect(self.user_input_db)
+        cursor = table.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS SuccessUserInput (
+                UserID TEXT,
+                Genus TEXT,
+                Species TEXT,
+                UniqueID TEXT PRIMARY KEY,
+                View TEXT,
+                Image BLOB,
+                Certainty TEXT
+            )
+        ''')
+        table.commit()
+        table.close()
         
     def uuid_generator(self):
         """

--- a/src/user_input_database.py
+++ b/src/user_input_database.py
@@ -1,0 +1,36 @@
+"""
+Creates and manages the user-input database
+"""
+
+import sqlite3
+import uuid
+
+class user_input_database:
+
+    def __init__(self, stored_dbase):
+        """
+        Sets up the database when the class is called. Creates an empty dbase 
+        if no input, initializes based on the previous version if given an input
+        """
+        pass
+        
+    def uuid_generator(self):
+        """
+        generates uuids for new images in the database
+        Returns: new uuid
+        """
+        return uuid.uuid4()
+    
+    def add_image(self):
+        """
+        Adds a new input image to the database
+        Returns: None
+        """
+        pass
+
+    def export_dbase(self, filename):
+        """
+        Exports the dbase to be stored when called
+        Returns: None
+        """
+

--- a/src/user_input_database.py
+++ b/src/user_input_database.py
@@ -8,12 +8,24 @@ import uuid
 
 class user_input_database:
 
-    def __init__(self, stored_dbase):
+    def __init__(self, dataset_dir_path):
         """
         Sets up the database when the class is called. Creates an empty dbase 
         if no input, initializes based on the previous version if given an input
         """
+        self.dir_path = dataset_dir_path
         self.user_input_db = 'user_input_database.db'
+
+    def img_to_binary(self, image_path):
+        """
+        **Taken from training data converter**
+
+        Translate given file path of image to binary
+        Return: binary file in bytes
+        """
+        with open(image_path, 'rb') as file:
+            binary_file = file.read()
+        return binary_file
 
     def build_user_db(self):
         """
@@ -42,12 +54,29 @@ class user_input_database:
         """
         return uuid.uuid4()
     
-    def add_image(self):
+    def add_image(self, image_data, image_binary):
         """
         Adds a new input image to the database
         Returns: None
         """
-        pass
+        table = sqlite3.connect(self.user_input_db)
+        cursor = table.cursor()
+        try:
+            # ensure array contains correct data
+            if len(image_data) != 6:
+                raise ValueError("image_data invalid, needs: [genus, species, unique_id, view]")
+
+            cursor.execute('''
+            INSERT INTO TrainingData (UserID, Genus, Species, UniqueID, View, Certainty, Image) 
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''', image_data + [image_binary])
+
+            table.commit()
+            print(f"Inserted Image UniqueID: {image_data[3]}")
+        except sqlite3.IntegrityError:
+            print(f"Image labeled, UniqueID {image_data[3]}, already exists.")
+        finally:
+            table.close()
 
     def export_dbase(self, filename):
         """

--- a/src/user_input_database.py
+++ b/src/user_input_database.py
@@ -6,9 +6,13 @@ import sqlite3
 import uuid
 
 
-class user_input_database:
+class UserInputDatabase:
+    """
+    Creates and manages the user input database. This database has two extra fields which are not
+    needed in the training database. This database is also separate from the training database
+    """
 
-    def __init__(self, dataset_dir_path, backup_file = None):
+    def __init__(self, dataset_dir_path, backup_file=None):
         """
         Sets up the database when the class is called. Creates an empty dbase 
         if no input, initializes based on the previous version if given an input
@@ -25,14 +29,14 @@ class user_input_database:
             conn = sqlite3.connect(self.user_input_db)
             cursor = conn.cursor()
 
-            with open(backup_file, "r") as file:
+            with open(backup_file, "r", encoding="utf-8") as file:
                 sql_contents = file.read()
 
             try:
                 cursor.executescript(sql_contents)
             except sqlite3.Error as e:
                 print(f"An error occured: {e}")
-            
+
             conn.commit()
             conn.close()
 
@@ -67,14 +71,14 @@ class user_input_database:
         ''')
         table.commit()
         table.close()
-        
+
     def uuid_generator(self):
         """
         generates uuids for new images in the database
         Returns: new uuid
         """
         return uuid.uuid4()
-    
+
     def add_image(self, image_data, image_binary):
         """
         Adds a new input image to the database
@@ -109,9 +113,8 @@ class user_input_database:
         """
         conn = sqlite3.connect(self.user_input_db)
 
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             for line in conn.iterdump():
                 file.write(f"{line}\n")
-        
-        conn.close()
 
+        conn.close()

--- a/testing/test_user_input_database.py
+++ b/testing/test_user_input_database.py
@@ -1,0 +1,24 @@
+"""
+Testing for user input database
+"""
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+import sys
+import os
+import io
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from user_input_database import user_input_database
+
+class test_user_input_database(unittest.TestCase):
+    
+    def test_uuid_generator():
+        """
+        Test proper return of uuid
+        """
+        pass
+    def test_add_image():
+        pass
+    def test_export_dbase():
+        pass
+    def test_init():
+        pass

--- a/testing/test_user_input_database.py
+++ b/testing/test_user_input_database.py
@@ -44,7 +44,7 @@ class test_user_input_database(unittest.TestCase):
         conn.cursor.return_value = cursor
 
         tdc = user_input_database('')
-        tdc.user_input_db = 'test_database.db'
+        
 
         # mock parameters
         data = ['TestID', 'TestGenus', 'TestSpecies', '12345', 'test_view', 'test_certainty']
@@ -53,7 +53,7 @@ class test_user_input_database(unittest.TestCase):
         tdc.add_image(data, image_binary)
 
         # check that img is added to database
-        cursor.execute.assert_called_once_with(
+        cursor.execute.assert_called_with(
             '''
             INSERT INTO TrainingData (UserID, Genus, Species, UniqueID, View, Certainty, Image) 
             VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -61,11 +61,9 @@ class test_user_input_database(unittest.TestCase):
         )
 
         # check for committing and closing db
-        conn.commit.assert_called_once()
-        conn.close.assert_called_once()
+        conn.commit.assert_called()
+        conn.close.assert_called()
 
-    def test_export_dbase(self):
-        pass
 
     @patch('sqlite3.connect')
     def test_init(self, mock_connect):
@@ -75,9 +73,8 @@ class test_user_input_database(unittest.TestCase):
         mock_connect.return_value = conn
         conn.cursor.return_value = cursor
         tdc = user_input_database('')
-        tdc.user_input_db = 'test_database.db'
-        tdc.build_user_db()
-        mock_connect.assert_called_once_with('test_database.db')
+        
+        mock_connect.assert_called_once_with('user_input_database.db')
         cursor.execute.assert_called_once()
         conn.commit.assert_called_once()
         conn.close.assert_called_once()

--- a/testing/test_user_input_database.py
+++ b/testing/test_user_input_database.py
@@ -6,19 +6,56 @@ from unittest.mock import patch, MagicMock, mock_open, call
 import sys
 import os
 import io
+import uuid
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 from user_input_database import user_input_database
 
 class test_user_input_database(unittest.TestCase):
-    
-    def test_uuid_generator():
+
+    def test_uuid_generator_format(self):
         """
-        Test proper return of uuid
+        Test proper return and format of uuid
         """
+        db = user_input_database()
+        generated = db.uuid_generator()
+        try:
+            # Try parsing the UUID to ensure it's valid
+            uuid_obj = uuid.UUID(str(generated))
+            assert str(uuid_obj) == str(generated), "Invalid UUID format"
+            print("Test passed: UUID format is valid")
+        except ValueError:
+            assert False, "Generated UUID is invalid"
+
+    def test_uuid_generator_uniqueness(self):
+        """
+        Test proper uniqueness of uuid
+        """
+        db = user_input_database()
+        uuids = {db.uuid_generator() for _ in range(1000)}  # Generate 1000 UUIDs
+        assert len(uuids) == 1000, "UUIDs are not unique"
+        print("Test passed: UUIDs are unique")
+
+    def test_add_image(self):
         pass
-    def test_add_image():
+
+    def test_export_dbase(self):
         pass
-    def test_export_dbase():
-        pass
-    def test_init():
-        pass
+
+    @patch('sqlite3.connect')
+    def test_init(self, mock_connect):
+        """ Test that database is properly built with respective columns """
+        conn = MagicMock()
+        cursor = MagicMock()
+        mock_connect.return_value = conn
+        conn.cursor.return_value = cursor
+        tdc = user_input_database()
+        tdc.db = 'test_database.db'
+        tdc.build_user_db()
+        mock_connect.assert_called_once_with('test_database.db')
+        cursor.execute.assert_called_once()
+        conn.commit.assert_called_once()
+        conn.close.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test_user_input_database.py
+++ b/testing/test_user_input_database.py
@@ -2,21 +2,23 @@
 Testing for user input database
 """
 import unittest
-from unittest.mock import patch, MagicMock, mock_open, call
+from unittest.mock import patch, MagicMock
 import sys
 import os
-import io
 import uuid
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-from user_input_database import user_input_database
+from user_input_database import UserInputDatabase
 
-class test_user_input_database(unittest.TestCase):
+class TestUserInputDatabase(unittest.TestCase):
+    """
+    Unit testing for the user input database
+    """
 
     def test_uuid_generator_format(self):
         """
         Test proper return and format of uuid
         """
-        db = user_input_database('')
+        db = UserInputDatabase('')
         generated = db.uuid_generator()
         try:
             # Try parsing the UUID to ensure it's valid
@@ -30,7 +32,7 @@ class test_user_input_database(unittest.TestCase):
         """
         Test proper uniqueness of uuid
         """
-        db = user_input_database('')
+        db = UserInputDatabase('')
         uuids = {db.uuid_generator() for _ in range(1000)}  # Generate 1000 UUIDs
         assert len(uuids) == 1000, "UUIDs are not unique"
         print("Test passed: UUIDs are unique")
@@ -43,8 +45,7 @@ class test_user_input_database(unittest.TestCase):
         mock_connect.return_value = conn
         conn.cursor.return_value = cursor
 
-        tdc = user_input_database('')
-        
+        tdc = UserInputDatabase('')
 
         # mock parameters
         data = ['TestID', 'TestGenus', 'TestSpecies', '12345', 'test_view', 'test_certainty']
@@ -72,8 +73,8 @@ class test_user_input_database(unittest.TestCase):
         cursor = MagicMock()
         mock_connect.return_value = conn
         conn.cursor.return_value = cursor
-        tdc = user_input_database('')
-        
+        tdc = UserInputDatabase('')
+
         mock_connect.assert_called_once_with('user_input_database.db')
         cursor.execute.assert_called_once()
         conn.commit.assert_called_once()


### PR DESCRIPTION
User input database implementation completed. Initializer allows for a specified backup file to create the db or a new db can be created from scratch if not specified. A uuid generator is available for creating ids for new images as well as a binary converter to help store the images properly. Adding images checks to ensure all data is there and adds rows to the db. Export allows for creation of a .sql backup file that can later be used to initialize the db with all previous data when needed.