### PR TITLE
Eval idx to species output

### DIFF
--- a/src/evaluation_method.py
+++ b/src/evaluation_method.py
@@ -157,13 +157,13 @@ class EvaluationMethod:
 
         match index:
             case 0:
-                return species_predictions[0], conf_scores[0]
+                return self.species_idx_dict[species_predictions[0]], conf_scores[0]
             case 1:
-                return species_predictions[1], conf_scores[1]
+                return self.species_idx_dict[species_predictions[1]], conf_scores[1]
             case 2:
-                return species_predictions[2], conf_scores[2]
+                return self.species_idx_dict[species_predictions[2]], conf_scores[2]
             case 3:
-                return species_predictions[3], conf_scores[3]
+                return self.species_idx_dict[species_predictions[3]], conf_scores[3]
 
 
     def weighted_eval(self, conf_scores, species_predictions):
@@ -192,7 +192,7 @@ class EvaluationMethod:
                 highest_score = j
                 highest_species = i
 
-        return highest_species, highest_score
+        return self.species_idx_dict[highest_species], highest_score
 
     def stacked_eval(self):
         """

--- a/src/evaluation_method.py
+++ b/src/evaluation_method.py
@@ -6,6 +6,7 @@ import sys
 import os
 from torchvision import transforms
 import torch
+import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 class EvaluationMethod:
@@ -14,7 +15,7 @@ class EvaluationMethod:
     loaded CNN models
     """
 
-    def __init__(self, height_filename, models_dict, eval_method):
+    def __init__(self, height_filename, models_dict, eval_method, species_filename):
         """
         Load the trained models for usage and have the class prepared for user input.
         During testing phases, determining which evaluation method defined below will 
@@ -26,9 +27,23 @@ class EvaluationMethod:
         self.weights = [0.25, 0.25, 0.25, 0.25]
         self.trained_models = models_dict
 
+        self.species_idx_dict = self.open_class_dictionary(species_filename)
+
         self.height = None
         with open("src/models/" + height_filename, 'r', encoding='utf-8') as file:
             self.height = int(file.readline().strip())
+
+    def open_class_dictionary(self, filename):
+        """
+        Open and save the class dictionary for use in the evaluation method 
+        to convert the model's index to a string species classification
+
+        Returns: dictionary defined by file
+        """
+        with open("src/models/" + filename, 'r', encoding='utf-8') as json_file:
+            class_dict = json.load(json_file)
+
+        return class_dict
 
     def evaluate_image(self, late=None, dors=None, fron=None, caud=None):
         """

--- a/src/evaluation_method.py
+++ b/src/evaluation_method.py
@@ -4,9 +4,9 @@ the loaded trained models and creates a combined classification output
 """
 import sys
 import os
+import json
 from torchvision import transforms
 import torch
-import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 class EvaluationMethod:

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         models[key].eval()
 
     # Inititialize the EvaluationMethod object with the heaviest eval method set
-    evaluator = EvaluationMethod("height.txt", models, 1)
+    evaluator = EvaluationMethod("height.txt", models, 1, "dict.json")
 
     # Get the images to be evaluated through user input
     LATE_PATH = "dataset/Callosobruchus chinensis GEM_187686348 5XEXT LATE.jpg"

--- a/testing/test_evaluation_method.py
+++ b/testing/test_evaluation_method.py
@@ -74,7 +74,7 @@ class TestEvaluationMethod(unittest.TestCase):
         species_predictions = [1, 2, 2, 3]
 
         prediction, score = evaluation.weighted_eval(conf_scores, species_predictions)
-        assertEqual(prediction, "mimosae")
+        self.assertEqual(prediction, "mimosae")
         assert score == given_weights[1] * conf_scores[1] + given_weights[2] * conf_scores[2]
 
     @patch("builtins.open", new_callable=mock_open, read_data="224")

--- a/testing/test_evaluation_method.py
+++ b/testing/test_evaluation_method.py
@@ -13,7 +13,8 @@ class TestEvaluationMethod(unittest.TestCase):
     Test the evaluation method class methods
     """
     @patch("builtins.open", new_callable=mock_open, read_data="224")
-    def test_initializer(self, mock_file):
+    @patch("json.load", return_value = {0:"objectus"})
+    def test_initializer(self, mock_json, mock_file):
         """test the initializer for proper setup"""
         #mock the models
         mock_models = {
@@ -23,14 +24,17 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud" : MagicMock()
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
 
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_called_once_with("src/models/json_mock.txt", 'r', encoding='utf-8')
+        mock_json.assert_called_once()
         self.assertEqual(evaluation.use_method, 1)
         #Change the weights to match the program's manually
         self.assertEqual(evaluation.weights, [0.25, 0.25, 0.25, 0.25])
         self.assertEqual(evaluation.trained_models, mock_models)
         self.assertEqual(evaluation.height, 224)
+        self.assertEqual(evaluation.species_idx_dict, {0:"objectus"})
 
 
     @patch("builtins.open", new_callable=mock_open, read_data="224")
@@ -43,7 +47,7 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud" : MagicMock()
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
 
         species, conf = evaluation.heaviest_is_best([0.1, 0.3, 0.5, 0.4],[1, 4, 6, 3])
@@ -60,7 +64,7 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud" : MagicMock()
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 2)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 2, "json_mock.txt")
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
         #must be changed if weights are adjusted in code
         given_weights = [0.25, 0.25, 0.25, 0.25]
@@ -81,7 +85,7 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud" : MagicMock()
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
         evaluation.height = 224
         fake_input = Image.new("RGB", (224, 224))
@@ -92,7 +96,8 @@ class TestEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([0])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.8, 0.1, 0.1]]))
-    def test_evaluate_image_single_input(self, mock_softmax, mock_max, mock_file):
+    @patch("json.load", return_value = {0:"objectus"})
+    def test_evaluate_image_single_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with a single image entered"""
         mock_models = {
             "late": MagicMock(return_value=torch.tensor([[0.1, 0.3, 0.6]])),
@@ -101,8 +106,9 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud": MagicMock(return_value=torch.tensor([[0.4, 0.4, 0.2]])),
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_json.assert_called_once()
 
         #mock transform_input for dummy output
         mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))
@@ -120,7 +126,8 @@ class TestEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([1])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.3, 0.6, 0.1]]))
-    def test_evaluate_image_multiple_input(self, mock_softmax, mock_max, mock_file):
+    @patch("json.load", return_value = {0:"objectus"})
+    def test_evaluate_image_multiple_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with multiple images entered"""
         mock_models = {
             "late": MagicMock(return_value=torch.tensor([[0.1, 0.3, 0.6]])),
@@ -129,8 +136,9 @@ class TestEvaluationMethod(unittest.TestCase):
             "caud": MagicMock(return_value=torch.tensor([[0.4, 0.4, 0.2]])),
         }
 
-        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1)
+        evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
         mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_json.assert_called_once()
 
         #mock transform_input for dummy output
         mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))

--- a/testing/test_evaluation_method.py
+++ b/testing/test_evaluation_method.py
@@ -2,7 +2,7 @@
 import unittest
 import sys
 import os
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, call, MagicMock
 from PIL import Image
 import torch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))

--- a/testing/test_evaluation_method.py
+++ b/testing/test_evaluation_method.py
@@ -26,8 +26,9 @@ class TestEvaluationMethod(unittest.TestCase):
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
 
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
-        mock_file.assert_called_once_with("src/models/json_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         mock_json.assert_called_once()
         self.assertEqual(evaluation.use_method, 1)
         #Change the weights to match the program's manually
@@ -48,7 +49,9 @@ class TestEvaluationMethod(unittest.TestCase):
         }
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         evaluation.species_idx_dict = {6:"chinensis"}
 
         species, conf = evaluation.heaviest_is_best([0.1, 0.3, 0.5, 0.4],[1, 4, 6, 3])
@@ -66,7 +69,9 @@ class TestEvaluationMethod(unittest.TestCase):
         }
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 2, "json_mock.txt")
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         evaluation.species_idx_dict = {2:"mimosae"}
         #must be changed if weights are adjusted in code
         given_weights = [0.25, 0.25, 0.25, 0.25]
@@ -88,7 +93,9 @@ class TestEvaluationMethod(unittest.TestCase):
         }
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         evaluation.height = 224
         fake_input = Image.new("RGB", (224, 224))
         result = evaluation.transform_input(fake_input)
@@ -109,7 +116,9 @@ class TestEvaluationMethod(unittest.TestCase):
         }
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         mock_json.assert_called_once()
 
         #mock transform_input for dummy output
@@ -139,7 +148,9 @@ class TestEvaluationMethod(unittest.TestCase):
         }
 
         evaluation = EvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
-        mock_file.assert_called_once_with("src/models/height_mock.txt", 'r', encoding='utf-8')
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
         mock_json.assert_called_once()
 
         #mock transform_input for dummy output


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added functionality to take a json file input with a dictionary inside to be saved to a dictionary variable in the code. Modified evaluation's outputs to give a species name based on the index from the newly imported dictionary.

## UI/UX Implementation

No changes made

## Model Updates

No changes made

### Data Models

No changes made

### Object-Oriented Models

Evaluation method class received a new method to read and store the contents of a .json file

## End-to-End Testing Instructions

Running simulator should now give a species name for the test output instead of an index! To check integration, ensure this happens or there may be an issue between exporting and importing the .json file containing the dictionary.
