### PR TITLE
Genus eval method

### DIFF
--- a/src/genus_evaluation_method.py
+++ b/src/genus_evaluation_method.py
@@ -48,7 +48,7 @@ class GenusEvaluationMethod:
         class_dict = {}
 
         for key, value in class_dict_read.items():
-            class_dict[int(key)] = value 
+            class_dict[int(key)] = value
 
         return class_dict
 

--- a/src/genus_evaluation_method.py
+++ b/src/genus_evaluation_method.py
@@ -1,0 +1,222 @@
+"""
+Method that takes in a user input image or set of user images and runs them through 
+the loaded trained models and creates a combined classification output
+"""
+import sys
+import os
+import json
+from torchvision import transforms
+import torch
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+
+class GenusEvaluationMethod:
+    """
+    Takes image input and creates a classification by running the image through
+    loaded CNN models
+    """
+
+    def __init__(self, height_filename, models_dict, eval_method, genus_filename):
+        """
+        Load the trained models for usage and have the class prepared for user input.
+        During testing phases, determining which evaluation method defined below will 
+        be chosen here as well
+        """
+        self.use_method = eval_method     #1 = heaviest, 2 = weighted, 3 = stacked
+
+        #weights for use in weighted eval. Can be tweaked later to optimize evaluation accuracy
+        self.weights = [0.25, 0.25, 0.25, 0.25]
+        self.trained_models = models_dict
+
+        self.genus_idx_dict = self.open_class_dictionary(genus_filename)
+
+        self.height = None
+        with open("src/models/" + height_filename, 'r', encoding='utf-8') as file:
+            self.height = int(file.readline().strip())
+
+    def open_class_dictionary(self, filename):
+        """
+        Open and save the class dictionary for use in the evaluation method 
+        to convert the model's index to a string species classification
+
+        Returns: dictionary defined by file
+        """
+        with open("src/models/" + filename, 'r', encoding='utf-8') as json_file:
+            class_dict = json.load(json_file)
+
+        return class_dict
+
+    def evaluate_image(self, late=None, dors=None, fron=None, caud=None):
+        """
+        Create an evaluation of the input image(s) by running each given image through
+        its respective model and then run the output of the models through the evaluation method
+        and return the classification
+
+        Returns: Classification of input images and confidence score. 
+                A return of None, -1 indicates an error
+        """
+        device = torch.device('mps' if torch.backends.mps.is_built() else 'cpu')
+
+        #define variables outside the if statements so they can be used in other method calls
+        predictions = {
+            "late" : {"score" : 0, "genus" : None},
+            "dors" : {"score" : 0, "genus" : None},
+            "fron" : {"score" : 0, "genus" : None},
+            "caud" : {"score" : 0, "genus" : None},
+        }
+
+        if late:
+            late_image = self.transform_input(late).to(device)
+
+            with torch.no_grad():
+                late_output = self.trained_models["late"].to(device)(late_image)
+
+            # Get the predicted class and confidence score
+            _, predicted_index = torch.max(late_output, 1)
+            predictions["late"]["score"] = torch.nn.functional.softmax(
+                late_output, dim=1)[0, predicted_index].item()
+            predictions["late"]["genus"] = predicted_index.item()
+
+        if dors:
+            #mirrors above usage but for the dors angle
+            dors_image = self.transform_input(dors).to(device)
+
+            with torch.no_grad():
+                dors_output = self.trained_models["dors"].to(device)(dors_image)
+
+            _, predicted_index = torch.max(dors_output, 1)
+            predictions["dors"]["score"] = torch.nn.functional.softmax(
+                dors_output, dim=1)[0, predicted_index].item()
+            predictions["dors"]["genus"] = predicted_index.item()
+
+        if fron:
+            #mirrors above usage but for the fron angle
+            fron_image = self.transform_input(fron).to(device)
+
+            with torch.no_grad():
+                fron_output = self.trained_models["fron"].to(device)(fron_image)
+
+            _, predicted_index = torch.max(fron_output, 1)
+            predictions["fron"]["score"] = torch.nn.functional.softmax(
+                fron_output, dim=1)[0, predicted_index].item()
+            predictions["fron"]["genus"] = predicted_index.item()
+
+        if caud:
+            #mirrors above usage but for the caud angle
+            caud_image = self.transform_input(caud).to(device)
+
+            with torch.no_grad():
+                caud_output = self.trained_models["caud"].to(device)(caud_image)
+
+            _, predicted_index = torch.max(caud_output, 1)
+            predictions["caud"]["score"] = torch.nn.functional.softmax(
+                caud_output, dim=1)[0, predicted_index].item()
+            predictions["caud"]["genus"] = predicted_index.item()
+
+        if self.use_method == 1:
+            #match uses the index returned from the method to decide which prediction to return
+            return self.heaviest_is_best([predictions["fron"]["score"],
+                                       predictions["dors"]["score"],
+                                       predictions["late"]["score"],
+                                       predictions["caud"]["score"]],
+                                      [predictions["fron"]["genus"],
+                                       predictions["dors"]["genus"],
+                                       predictions["late"]["genus"],
+                                       predictions["caud"]["genus"]])
+
+        if self.use_method == 2:
+            return self.weighted_eval([predictions["fron"]["score"],
+                                       predictions["dors"]["score"],
+                                       predictions["late"]["score"],
+                                       predictions["caud"]["score"]],
+                                      [predictions["fron"]["genus"],
+                                       predictions["dors"]["genus"],
+                                       predictions["late"]["genus"],
+                                       predictions["caud"]["genus"]])
+
+        if self.use_method == 3:
+            return self.stacked_eval()
+
+        return None, -1
+
+    def heaviest_is_best(self, conf_scores, genus_predictions):
+        """
+        Takes the certainties of the models and returns the most 
+        certain model's specification
+
+        Returns: specifies most certain model
+        """
+        highest = 0
+        index = 0
+        ind_tracker = 0
+        for i in conf_scores:
+            if i > highest:
+                highest = i
+                index = ind_tracker
+
+            ind_tracker += 1
+
+        match index:
+            case 0:
+                return self.genus_idx_dict[genus_predictions[0]], conf_scores[0]
+            case 1:
+                return self.genus_idx_dict[genus_predictions[1]], conf_scores[1]
+            case 2:
+                return self.genus_idx_dict[genus_predictions[2]], conf_scores[2]
+            case 3:
+                return self.genus_idx_dict[genus_predictions[3]], conf_scores[3]
+
+
+    def weighted_eval(self, conf_scores, genus_predictions):
+        """
+        Takes the classifications of the models and combines them based on programmer determined
+        weights to create a single output
+
+        Returns: classification of combined models
+        """
+        species_scores = {}
+
+        for i in range(4):
+            weighted_score = self.weights[i] * conf_scores[i]
+
+            if genus_predictions[i] in species_scores:
+                species_scores[genus_predictions[i]] += weighted_score
+
+            else:
+                species_scores[genus_predictions[i]] = weighted_score
+
+        highest_score = -1
+        highest_species = None
+
+        for i, j in species_scores.items():
+            if j > highest_score:
+                highest_score = j
+                highest_species = i
+
+        return self.genus_idx_dict[highest_species], highest_score
+
+    def stacked_eval(self):
+        """
+        Takes the classifications of the models and runs them through another model that determines
+        the overall output
+
+        REACH CASE/STUB FOR SPRINT 3
+
+        Returns: classification of combined models
+        """
+
+    def transform_input(self, image_input):
+        """
+        Takes the app side's image and transforms it to fit our model
+
+        Returns: transformed image for classification
+        """
+        transformation = transforms.Compose([
+            transforms.Resize((self.height, self.height)), #ResNet expects 224x224 images
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        ])
+
+        transformed_image = transformation(image_input)
+        transformed_image = transformed_image.unsqueeze(0)
+
+        return transformed_image

--- a/src/genus_evaluation_method.py
+++ b/src/genus_evaluation_method.py
@@ -41,11 +41,14 @@ class GenusEvaluationMethod:
         Returns: dictionary defined by file
         """
         with open("src/models/" + filename, 'r', encoding='utf-8') as json_file:
-            class_dict = json.load(json_file)
+            class_dict_read = json.load(json_file)
 
         #Convert string keys to integers(keys automatically switched by json save)
         #Undoes issues created by json saving
-        class_dict = {int(key): value for key, value in class_dict.items()}
+        class_dict = {}
+
+        for key, value in class_dict_read.items():
+            class_dict[int(key)] = value 
 
         return class_dict
 

--- a/src/genus_evaluation_method.py
+++ b/src/genus_evaluation_method.py
@@ -43,6 +43,10 @@ class GenusEvaluationMethod:
         with open("src/models/" + filename, 'r', encoding='utf-8') as json_file:
             class_dict = json.load(json_file)
 
+        #Convert string keys to integers(keys automatically switched by json save)
+        #Undoes issues created by json saving
+        class_dict = {int(key): value for key, value in class_dict.items()}
+
         return class_dict
 
     def evaluate_image(self, late=None, dors=None, fron=None, caud=None):

--- a/testing/test_genus_evaluation_method.py
+++ b/testing/test_genus_evaluation_method.py
@@ -137,7 +137,8 @@ class TestGenusEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([1])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.3, 0.6, 0.1]]))
-    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus", 2:"mimosestes", 3:"phaseoli"})
+    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus", 
+                                        2:"mimosestes", 3:"phaseoli"})
     def test_evaluate_image_multiple_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with multiple images entered"""
         mock_models = {

--- a/testing/test_genus_evaluation_method.py
+++ b/testing/test_genus_evaluation_method.py
@@ -137,7 +137,7 @@ class TestGenusEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([1])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.3, 0.6, 0.1]]))
-    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus", 
+    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus",
                                         2:"mimosestes", 3:"phaseoli"})
     def test_evaluate_image_multiple_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with multiple images entered"""

--- a/testing/test_genus_evaluation_method.py
+++ b/testing/test_genus_evaluation_method.py
@@ -13,7 +13,7 @@ class TestGenusEvaluationMethod(unittest.TestCase):
     Test the evaluation method class methods
     """
     @patch("builtins.open", new_callable=mock_open, read_data="224")
-    @patch("json.load", return_value = {0:"acanthoscelides"})
+    @patch("json.load", return_value = {"0":"acanthoscelides"})
     def test_initializer(self, mock_json, mock_file):
         """test the initializer for proper setup"""
         #mock the models
@@ -35,11 +35,12 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         self.assertEqual(evaluation.weights, [0.25, 0.25, 0.25, 0.25])
         self.assertEqual(evaluation.trained_models, mock_models)
         self.assertEqual(evaluation.height, 224)
-        self.assertEqual(evaluation.species_idx_dict, {0:"acanthoscelides"})
+        self.assertEqual(evaluation.genus_idx_dict, {0:"acanthoscelides"})
 
 
     @patch("builtins.open", new_callable=mock_open, read_data="224")
-    def test_heaviest_is_best(self, mock_file):
+    @patch("json.load", return_value = {"0":"acanthoscelides"})
+    def test_heaviest_is_best(self, mock_json, mock_file):
         """test heaviest is best for proper tracking of highest certainty"""
         mock_models = {
             "late" : MagicMock(),
@@ -52,14 +53,16 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
                                     call("src/models/json_mock.txt", 'r', encoding='utf-8')],
                                     any_order = True)
-        evaluation.species_idx_dict = {6:"chinensis"}
+        mock_json.assert_called_once()
+        evaluation.genus_idx_dict = {6:"chinensis"}
 
-        species, conf = evaluation.heaviest_is_best([0.1, 0.3, 0.5, 0.4],[1, 4, 6, 3])
-        self.assertEqual(species, "chinensis")
+        genus, conf = evaluation.heaviest_is_best([0.1, 0.3, 0.5, 0.4],[1, 4, 6, 3])
+        self.assertEqual(genus, "chinensis")
         self.assertEqual(conf, 0.5)
 
     @patch("builtins.open", new_callable=mock_open, read_data="224")
-    def test_weighted_eval(self, mock_file):
+    @patch("json.load", return_value = {"0":"acanthoscelides"})
+    def test_weighted_eval(self, mock_json, mock_file):
         """test weighted eval for proper calculation"""
         mock_models = {
             "late" : MagicMock(),
@@ -72,18 +75,20 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
                                     call("src/models/json_mock.txt", 'r', encoding='utf-8')],
                                     any_order = True)
-        evaluation.species_idx_dict = {2:"mimosae"}
+        mock_json.assert_called_once()
+        evaluation.genus_idx_dict = {2:"mimosae"}
         #must be changed if weights are adjusted in code
         given_weights = [0.25, 0.25, 0.25, 0.25]
         conf_scores = [0.8, 0.6, 0.9, 0.7]
-        species_predictions = [1, 2, 2, 3]
+        genus_predictions = [1, 2, 2, 3]
 
-        prediction, score = evaluation.weighted_eval(conf_scores, species_predictions)
+        prediction, score = evaluation.weighted_eval(conf_scores, genus_predictions)
         self.assertEqual(prediction, "mimosae")
         assert score == given_weights[1] * conf_scores[1] + given_weights[2] * conf_scores[2]
 
     @patch("builtins.open", new_callable=mock_open, read_data="224")
-    def test_transform_input(self, mock_file):
+    @patch("json.load", return_value = {"0":"acanthoscelides"})
+    def test_transform_input(self, mock_json, mock_file):
         """test transform input for proper image transformation"""
         mock_models = {
             "late" : MagicMock(),
@@ -96,6 +101,7 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
                                     call("src/models/json_mock.txt", 'r', encoding='utf-8')],
                                     any_order = True)
+        mock_json.assert_called_once()
         evaluation.height = 224
         fake_input = Image.new("RGB", (224, 224))
         result = evaluation.transform_input(fake_input)
@@ -105,7 +111,7 @@ class TestGenusEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([0])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.8, 0.1, 0.1]]))
-    @patch("json.load", return_value = {0:"acanthoscelides"})
+    @patch("json.load", return_value = {"0":"acanthoscelides"})
     def test_evaluate_image_single_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with a single image entered"""
         mock_models = {
@@ -125,9 +131,9 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))
         evaluation.transform_input = mock_transform
 
-        result_species, result_conf = evaluation.evaluate_image(late=Image.new("RGB", (224, 224)))
+        result_genus, result_conf = evaluation.evaluate_image(late=Image.new("RGB", (224, 224)))
 
-        self.assertEqual(result_species, "acanthoscelides")
+        self.assertEqual(result_genus, "acanthoscelides")
         self.assertEqual(round(result_conf, 2), 0.8)
 
         mock_transform.assert_called_once()
@@ -137,8 +143,8 @@ class TestGenusEvaluationMethod(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="224")
     @patch("torch.max", return_value=(None, torch.tensor([1])))
     @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.3, 0.6, 0.1]]))
-    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus",
-                                        2:"mimosestes", 3:"phaseoli"})
+    @patch("json.load", return_value = {"0":"acanthoscelides", "1":"callosobruchus",
+                                        "2":"mimosestes", "3":"phaseoli"})
     def test_evaluate_image_multiple_input(self, mock_json, mock_softmax, mock_max, mock_file):
         """test proper output with multiple images entered"""
         mock_models = {
@@ -158,13 +164,13 @@ class TestGenusEvaluationMethod(unittest.TestCase):
         mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))
         evaluation.transform_input = mock_transform
 
-        result_species, result_conf = evaluation.evaluate_image(
+        result_genus, result_conf = evaluation.evaluate_image(
             late=Image.new("RGB", (224, 224)),
             dors=Image.new("RGB", (224, 224)),
             fron=Image.new("RGB", (224, 224)),
             caud=Image.new("RGB", (224, 224)))
 
-        self.assertEqual(result_species, "callosobruchus")
+        self.assertEqual(result_genus, "callosobruchus")
         self.assertEqual(round(result_conf, 2), 0.6)
 
         self.assertEqual(mock_transform.call_count, 4)

--- a/testing/test_genus_evaluation_method.py
+++ b/testing/test_genus_evaluation_method.py
@@ -1,0 +1,174 @@
+"""test_evaluation_method.py"""
+import unittest
+import sys
+import os
+from unittest.mock import patch, mock_open, call, MagicMock
+from PIL import Image
+import torch
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from genus_evaluation_method import GenusEvaluationMethod
+
+class TestGenusEvaluationMethod(unittest.TestCase):
+    """
+    Test the evaluation method class methods
+    """
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    @patch("json.load", return_value = {0:"acanthoscelides"})
+    def test_initializer(self, mock_json, mock_file):
+        """test the initializer for proper setup"""
+        #mock the models
+        mock_models = {
+            "late" : MagicMock(),
+            "fron" : MagicMock(),
+            "dors" : MagicMock(),
+            "caud" : MagicMock()
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
+
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        mock_json.assert_called_once()
+        self.assertEqual(evaluation.use_method, 1)
+        #Change the weights to match the program's manually
+        self.assertEqual(evaluation.weights, [0.25, 0.25, 0.25, 0.25])
+        self.assertEqual(evaluation.trained_models, mock_models)
+        self.assertEqual(evaluation.height, 224)
+        self.assertEqual(evaluation.species_idx_dict, {0:"acanthoscelides"})
+
+
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    def test_heaviest_is_best(self, mock_file):
+        """test heaviest is best for proper tracking of highest certainty"""
+        mock_models = {
+            "late" : MagicMock(),
+            "fron" : MagicMock(),
+            "dors" : MagicMock(),
+            "caud" : MagicMock()
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        evaluation.species_idx_dict = {6:"chinensis"}
+
+        species, conf = evaluation.heaviest_is_best([0.1, 0.3, 0.5, 0.4],[1, 4, 6, 3])
+        self.assertEqual(species, "chinensis")
+        self.assertEqual(conf, 0.5)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    def test_weighted_eval(self, mock_file):
+        """test weighted eval for proper calculation"""
+        mock_models = {
+            "late" : MagicMock(),
+            "fron" : MagicMock(),
+            "dors" : MagicMock(),
+            "caud" : MagicMock()
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 2, "json_mock.txt")
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        evaluation.species_idx_dict = {2:"mimosae"}
+        #must be changed if weights are adjusted in code
+        given_weights = [0.25, 0.25, 0.25, 0.25]
+        conf_scores = [0.8, 0.6, 0.9, 0.7]
+        species_predictions = [1, 2, 2, 3]
+
+        prediction, score = evaluation.weighted_eval(conf_scores, species_predictions)
+        self.assertEqual(prediction, "mimosae")
+        assert score == given_weights[1] * conf_scores[1] + given_weights[2] * conf_scores[2]
+
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    def test_transform_input(self, mock_file):
+        """test transform input for proper image transformation"""
+        mock_models = {
+            "late" : MagicMock(),
+            "fron" : MagicMock(),
+            "dors" : MagicMock(),
+            "caud" : MagicMock()
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        evaluation.height = 224
+        fake_input = Image.new("RGB", (224, 224))
+        result = evaluation.transform_input(fake_input)
+
+        assert result.shape == (1, 3, 224, 224)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    @patch("torch.max", return_value=(None, torch.tensor([0])))
+    @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.8, 0.1, 0.1]]))
+    @patch("json.load", return_value = {0:"acanthoscelides"})
+    def test_evaluate_image_single_input(self, mock_json, mock_softmax, mock_max, mock_file):
+        """test proper output with a single image entered"""
+        mock_models = {
+            "late": MagicMock(return_value=torch.tensor([[0.1, 0.3, 0.6]])),
+            "dors": MagicMock(return_value=torch.tensor([[0.2, 0.5, 0.3]])),
+            "fron": MagicMock(return_value=torch.tensor([[0.7, 0.2, 0.1]])),
+            "caud": MagicMock(return_value=torch.tensor([[0.4, 0.4, 0.2]])),
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        mock_json.assert_called_once()
+
+        #mock transform_input for dummy output
+        mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))
+        evaluation.transform_input = mock_transform
+
+        result_species, result_conf = evaluation.evaluate_image(late=Image.new("RGB", (224, 224)))
+
+        self.assertEqual(result_species, "acanthoscelides")
+        self.assertEqual(round(result_conf, 2), 0.8)
+
+        mock_transform.assert_called_once()
+        mock_softmax.assert_called_once()
+        mock_max.assert_called_once()
+
+    @patch("builtins.open", new_callable=mock_open, read_data="224")
+    @patch("torch.max", return_value=(None, torch.tensor([1])))
+    @patch("torch.nn.functional.softmax", return_value=torch.tensor([[0.3, 0.6, 0.1]]))
+    @patch("json.load", return_value = {0:"acanthoscelides", 1:"callosobruchus", 2:"mimosestes", 3:"phaseoli"})
+    def test_evaluate_image_multiple_input(self, mock_json, mock_softmax, mock_max, mock_file):
+        """test proper output with multiple images entered"""
+        mock_models = {
+            "late": MagicMock(return_value=torch.tensor([[0.1, 0.3, 0.6]])),
+            "dors": MagicMock(return_value=torch.tensor([[0.2, 0.5, 0.3]])),
+            "fron": MagicMock(return_value=torch.tensor([[0.7, 0.2, 0.1]])),
+            "caud": MagicMock(return_value=torch.tensor([[0.4, 0.4, 0.2]])),
+        }
+
+        evaluation = GenusEvaluationMethod("height_mock.txt", mock_models, 1, "json_mock.txt")
+        mock_file.assert_has_calls([call("src/models/height_mock.txt", 'r', encoding='utf-8'),
+                                    call("src/models/json_mock.txt", 'r', encoding='utf-8')],
+                                    any_order = True)
+        mock_json.assert_called_once()
+
+        #mock transform_input for dummy output
+        mock_transform = MagicMock(return_value = torch.rand(1, 3, 224, 224))
+        evaluation.transform_input = mock_transform
+
+        result_species, result_conf = evaluation.evaluate_image(
+            late=Image.new("RGB", (224, 224)),
+            dors=Image.new("RGB", (224, 224)),
+            fron=Image.new("RGB", (224, 224)),
+            caud=Image.new("RGB", (224, 224)))
+
+        self.assertEqual(result_species, "callosobruchus")
+        self.assertEqual(round(result_conf, 2), 0.6)
+
+        self.assertEqual(mock_transform.call_count, 4)
+        self.assertEqual(mock_max.call_count, 4)
+        self.assertEqual(mock_softmax.call_count, 4)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature
**Summary:** Added a new class for evaluating and returning a single genus to complement the species evaluation.

## UI/UX Implementation

No changes

## Model Updates

This feature adds a fifth model that evaluates images to return the genus instead of species (utilizes new models trained to recognize genus instead of species)

### Data Models

New models are trained and added next to the four we already have which are focused on identifying the genus instead of the species of the specimen

### Object-Oriented Models

no changes made.

## End-to-End Testing Instructions

Test EtoE after genus training program and the genus model loader are complete via the same method the species evaluation method is tested.
