### PR TITLE
Fixed a mismatched index bug in genus heaviest is best method

### DIFF
--- a/src/genus_evaluation_method.py
+++ b/src/genus_evaluation_method.py
@@ -229,7 +229,7 @@ class GenusEvaluationMethod:
             acc_dict_reverse = {v:k for k, v in accuracy_dict.items()}
             for i in conf_scores:
                 if i != 0:
-                    accs.append(accuracy_dict[angle_list[i]])
+                    accs.append(accuracy_dict[angle_list[conf_scores.index(i)]])
             use_angle = acc_dict_reverse[max(accs)]
 
         elif genus_predictions[1] is not None:


### PR DESCRIPTION
# Overview

**Type of Change:** Bug fix

**Summary:** Changed a line in genus eval's heaviest is best to take the index of the confidence score instead of the confidence score as the index of the angle being used.

## UI/UX Implementation

No changes made.

## Model Updates

No changes made.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

Test eval simulator for the genus classification in specific to ensure that the proper classification is found
